### PR TITLE
Skip metastore partition fetch on incremental hive sync

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -85,6 +85,11 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       .withDocumentation("Max size limit to push down partition filters, if the estimate push down "
           + "filters exceed this size, will directly try to fetch all partitions");
 
+  public static final ConfigProperty<Boolean> HIVE_SYNC_SKIP_UPDATE_EVENTS = ConfigProperty
+          .key("hoodie.datasource.hive_sync.skip_update_events")
+          .defaultValue(false)
+          .withDocumentation("When true, only performs add and drop events, without fetching partitions from HMS");
+
   public static String getBucketSpec(String bucketCols, int bucketNum) {
     return "CLUSTERED BY (" + bucketCols + " INTO " + bucketNum + " BUCKETS";
   }
@@ -169,6 +174,9 @@ public class HiveSyncConfig extends HoodieSyncConfig {
     @Parameter(names = {"--sync-strategy"}, description = "Hive table synchronization strategy. Available option: RO, RT, ALL")
     public String syncStrategy;
 
+    @Parameter(names = {"--skip-update-events"}, description = "Whether to skip update events, which avoids fetching partitions from HMS")
+    public Boolean skipUpdateEvents;
+
     public boolean isHelp() {
       return hoodieSyncConfigParams.isHelp();
     }
@@ -197,6 +205,7 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       props.setPropertyIfNonNull(HIVE_SYNC_BUCKET_SYNC_SPEC.key(), bucketSpec);
       props.setPropertyIfNonNull(HIVE_SYNC_COMMENT.key(), syncComment);
       props.setPropertyIfNonNull(HIVE_SYNC_TABLE_STRATEGY.key(), syncStrategy);
+      props.setPropertyIfNonNull(HIVE_SYNC_SKIP_UPDATE_EVENTS.key(), skipUpdateEvents);
       return props;
     }
   }

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -164,4 +164,20 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
     }
     return events;
   }
+
+  public List<PartitionEvent> getPartitionAddAndDropEventsOnly(List<String> partitionStoragePartitions, Set<String> droppedPartitions) {
+    List<PartitionEvent> events = new ArrayList<>();
+    for (String storagePartition : partitionStoragePartitions) {
+      List<String> storagePartitionValues = partitionValueExtractor.extractPartitionValuesInPath(storagePartition);
+
+      if (droppedPartitions.contains(storagePartition)) {
+        events.add(PartitionEvent.newPartitionDropEvent(storagePartition));
+      } else {
+        if (!storagePartitionValues.isEmpty()) {
+          events.add(PartitionEvent.newPartitionAddEvent(storagePartition));
+        }
+      }
+    }
+    return events;
+  }
 }


### PR DESCRIPTION
This essentially removes the support for updating partitions when the path on storage changes which should never occur in our case.