### PR TITLE
[PA-9141] optimize processing cleaner timeline in hive sync

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -105,7 +105,7 @@ public class TimelineUtils {
             .map(partition -> new AbstractMap.SimpleEntry<>(partition, pair.getLeft().getTimestamp()))
         ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replace) -> replace));
     // cleaner could delete a partition when there are no active filegroups in the partition
-    HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+    HoodieTimeline cleanerTimeline = TimelineUtils.getCleanerTimelineAfter(metaClient, lastCommitTimeSynced.get(), lastCommitCompletionTimeSynced).filterCompletedInstants();
     cleanerTimeline.getInstantsAsStream()
         .forEach(instant -> {
           try {
@@ -138,7 +138,6 @@ public class TimelineUtils {
             throw new HoodieIOException("Failed to get partitions writes at " + instant, e);
           }
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replace) -> replace));
-
     return partitionToLatestDeleteTimestamp.entrySet().stream()
         .filter(entry -> !partitionToLatestWriteTimestamp.containsKey(entry.getKey())
             || compareTimestamps(entry.getValue(), GREATER_THAN, partitionToLatestWriteTimestamp.get(entry.getKey()))
@@ -213,7 +212,7 @@ public class TimelineUtils {
    */
   public static Option<String> getExtraMetadataFromLatest(HoodieTableMetaClient metaClient, String extraMetadataKey) {
     return metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
-        // exclude clustering commits for returning user stored extra metadata 
+        // exclude clustering commits for returning user stored extra metadata
         .filter(instant -> !isClusteringCommit(metaClient, instant))
         .findFirst().map(instant ->
             getMetadataValue(metaClient, extraMetadataKey, instant)).orElse(Option.empty());
@@ -252,7 +251,7 @@ public class TimelineUtils {
   public static boolean isClusteringCommit(HoodieTableMetaClient metaClient, HoodieInstant instant) {
     try {
       if (REPLACE_COMMIT_ACTION.equals(instant.getAction())) {
-        // replacecommit is used for multiple operations: insert_overwrite/cluster etc. 
+        // replacecommit is used for multiple operations: insert_overwrite/cluster etc.
         // Check operation type to see if this instant is related to clustering.
         HoodieReplaceCommitMetadata replaceMetadata = HoodieReplaceCommitMetadata.fromBytes(
             metaClient.getActiveTimeline().getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
@@ -304,6 +303,28 @@ public class TimelineUtils {
     }
 
     return timelineSinceLastSync;
+  }
+
+  /**
+   * Returns a Hudi timeline with cleaner commits after the given instant time (exclusive).
+   * Assumes all required clean commits are on the active timeline.
+   *
+   * @param metaClient                {@link HoodieTableMetaClient} instance.
+   * @param exclusiveStartInstantTime Start instant time (exclusive).
+   * @param lastMaxCompletionTime     Last commit max completion time synced
+   * @return Hudi timeline.
+   */
+  public static HoodieTimeline getCleanerTimelineAfter(
+          HoodieTableMetaClient metaClient, String exclusiveStartInstantTime, Option<String> lastMaxCompletionTime) {
+    HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline();
+
+    // return commits meeting one of the conditions:
+    // - instant timestamp (start time) after `exclusiveStartInstantTime`
+    // - instant timestamp (start time) before `exclusiveStartInstantTime` and transition time after `lastMaxCompletionTime`
+    return cleanerTimeline.filter(s ->
+      compareTimestamps(s.getTimestamp(), GREATER_THAN, exclusiveStartInstantTime) ||
+              (compareTimestamps(s.getTimestamp(), LESSER_THAN, exclusiveStartInstantTime) && compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, lastMaxCompletionTime.get()))
+    );
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -198,7 +198,7 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       props.setPropertyIfNonNull(HIVE_SUPPORT_TIMESTAMP_TYPE.key(), supportTimestamp);
       props.setPropertyIfNonNull(HIVE_TABLE_PROPERTIES.key(), tableProperties);
       props.setPropertyIfNonNull(HIVE_TABLE_SERDE_PROPERTIES.key(), serdeProperties);
-      props.setPropertyIfNonNull(HIVE_SYNC_AS_DATA_SOURCE_TABLE.key(), syncAsSparkDataSourceTable);
+      props.setPropertyIfNonNull(HIVE_SYNC_AS_DATA_SOURCE_TABLE.key(), false);
       props.setPropertyIfNonNull(HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD.key(), sparkSchemaLengthThreshold);
       props.setPropertyIfNonNull(HIVE_CREATE_MANAGED_TABLE.key(), createManagedTable);
       props.setPropertyIfNonNull(HIVE_SYNC_OMIT_METADATA_FIELDS.key(), omitMetaFields);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -283,11 +283,12 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       partitionsChanged = syncAllPartitions(tableName);
     } else {
       List<String> writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced, lastCommitCompletionTimeSynced);
-      LOG.info("Storage partitions scan complete. Found " + writtenPartitionsSince.size());
+      LOG.info("Found " + writtenPartitionsSince.size() + " new partitions");
 
       // Sync the partitions if needed
       // find dropped partitions, if any, in the latest commit
       Set<String> droppedPartitions = syncClient.getDroppedPartitionsSince(lastCommitTimeSynced, lastCommitCompletionTimeSynced);
+      LOG.info("Found " + droppedPartitions.size() + " dropped partitions");
       partitionsChanged = syncPartitions(tableName, writtenPartitionsSince, droppedPartitions);
     }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -283,7 +283,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       partitionsChanged = syncAllPartitions(tableName);
     } else {
       List<String> writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced, lastCommitCompletionTimeSynced);
-      LOG.info("Found " + writtenPartitionsSince.size() + " new partitions");
+      LOG.info("Found " + writtenPartitionsSince.size() + " written partitions");
 
       // Sync the partitions if needed
       // find dropped partitions, if any, in the latest commit


### PR DESCRIPTION
Since https://github.com/apache/hudi/pull/10676 the Hive sync considers cleaner commit to compute dropped partitions. The code processes _all_ clean commits on the active timeline and there are a lot of commits on our timeline which causes it to OOM. This change filters the timeline to only consider commits completed since the last sync. The filtering is similar to https://github.com/heap/hudi/blob/f605f28d989536ef4044d818c91fcd00fa624a9f/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java#L287 but only considers the active timeline and not the archived one so it's a bit simpler.