### PR TITLE
PA-9395: Parallelize partition deletes. More logging.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -52,6 +52,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   private static final String CLEANER_HOURS_RETAINED_KEY = "hoodie.cleaner.hours.retained";
 
   private static final String CLEANER_ROLLBACK_ONLY_KEY = "hoodie.cleaner.rollback_only";
+  private static final String CLEANER_PARALLELIZE_PARTITION_CLEANING_KEY = "hoodie.cleaner.parallelize_partition_cleaning";
   private static final String CLEANER_FILE_VERSIONS_RETAINED_KEY = "hoodie.cleaner.fileversions.retained";
 
   public static final ConfigProperty<String> AUTO_CLEAN = ConfigProperty
@@ -116,6 +117,11 @@ public class HoodieCleanConfig extends HoodieConfig {
           .defaultValue("false")
           .markAdvanced()
           .withDocumentation("TODO");
+
+  public static final ConfigProperty<String> CLEANER_PARALLELIZE_PARTITION_CLEANING = ConfigProperty.key(CLEANER_PARALLELIZE_PARTITION_CLEANING_KEY)
+        .defaultValue("false")
+        .markAdvanced()
+        .withDocumentation("If there are any partitions to be deleted in the clean plan, setting this to true will parallelize this deletion. Otherwise the deletes will be processed by the driver");
 
   public static final ConfigProperty<String> CLEANER_FILE_VERSIONS_RETAINED = ConfigProperty
       .key(CLEANER_FILE_VERSIONS_RETAINED_KEY)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1503,6 +1503,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieCleanConfig.CLEANER_ROLLBACK_ONLY);
   }
 
+  public boolean parallelizePartitionCleaning() {
+    return getBoolean(HoodieCleanConfig.CLEANER_PARALLELIZE_PARTITION_CLEANING);
+  }
+
   public int getMaxCommitsToKeep() {
     return getInt(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
@@ -73,20 +74,23 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     this.skipLocking = skipLocking;
   }
 
-  private static Boolean deleteFileAndGetResult(FileSystem fs, String deletePathStr) throws IOException {
+  private static Boolean deleteFileAndGetResult(FileSystem fs, String deletePathStr, Integer count) throws IOException {
     Path deletePath = new Path(deletePathStr);
-    LOG.debug("Working on delete path :" + deletePath);
+    LOG.info("***--- Working on delete path :" + deletePath);
     try {
       boolean isDirectory = fs.isDirectory(deletePath);
       boolean deleteResult = fs.delete(deletePath, isDirectory);
       if (deleteResult) {
-        LOG.debug("Cleaned file at path :" + deletePath);
+        LOG.info("***--- Cleaned file at path :" + deletePath);
       } else {
         if (fs.exists(deletePath)) {
           throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
         } else {
-          LOG.debug("Already cleaned up file at path :" + deletePath);
+          LOG.info("***--- Already cleaned up file at path :" + deletePath);
         }
+      }
+      if (count % 1000 == 0) {
+        LOG.info("***--- delete paths processed: " + count);
       }
       return deleteResult;
     } catch (FileNotFoundException fio) {
@@ -99,14 +103,16 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     Map<String, PartitionCleanStat> partitionCleanStatMap = new HashMap<>();
     FileSystem fs = (FileSystem) table.getStorage().getFileSystem();
 
+    AtomicInteger count = new AtomicInteger(0);
     cleanFileInfo.forEachRemaining(partitionDelFileTuple -> {
+      count.incrementAndGet();
       String partitionPath = partitionDelFileTuple.getLeft();
+      LOG.info("***--- Partition path: " + partitionPath);
       Path deletePath = new Path(partitionDelFileTuple.getRight().getFilePath());
       String deletePathStr = deletePath.toString();
       boolean deletedFileResult = false;
       try {
-        deletedFileResult = deleteFileAndGetResult(fs, deletePathStr);
-
+        deletedFileResult = deleteFileAndGetResult(fs, deletePathStr, count.get());
       } catch (IOException e) {
         LOG.error("Delete file failed: " + deletePathStr, e);
       }
@@ -149,17 +155,21 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         context.mapPartitionsToPairAndReduceByKey(filesToBeDeletedPerPartition,
             iterator -> deleteFilesFunc(iterator, table), PartitionCleanStat::merge, cleanerParallelism);
 
-    Map<String, PartitionCleanStat> partitionCleanStatsMap = partitionCleanStats
+    LOG.info("Collecting cleaner stats");
+      Map<String, PartitionCleanStat> partitionCleanStatsMap = partitionCleanStats
         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     List<String> partitionsToBeDeleted = table.getMetaClient().getTableConfig().isTablePartitioned() && cleanerPlan.getPartitionsToBeDeleted() != null
         ? cleanerPlan.getPartitionsToBeDeleted()
         : new ArrayList<>();
+    AtomicInteger count = new AtomicInteger(0);
+    LOG.info("***--- metaclient partitions to be deleted: " + partitionsToBeDeleted.size());
     partitionsToBeDeleted.forEach(entry -> {
       try {
         if (!isNullOrEmpty(entry)) {
+          count.incrementAndGet();
           deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
-              table.getMetaClient().getBasePath() + "/" + entry);
+              table.getMetaClient().getBasePath() + "/" + entry, count.get());
         }
       } catch (IOException e) {
         LOG.warn("Partition deletion failed " + entry);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -177,7 +177,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
       });
     }
 
-      // Return PartitionCleanStat for each partition passed.
+    // Return PartitionCleanStat for each partition passed.
     return cleanerPlan.getFilePathsToBeDeletedPerPartition().keySet().stream().map(partitionPath -> {
       PartitionCleanStat partitionCleanStat = partitionCleanStatsMap.containsKey(partitionPath)
           ? partitionCleanStatsMap.get(partitionPath)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -138,7 +138,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         config.getCleanerParallelism());
     LOG.info("Using cleanerParallelism: " + cleanerParallelism);
 
-    context.setJobStatus(this.getClass().getSimpleName(), "Perform cleaning of table: " + config.getTableName());
+    context.setJobStatus(this.getClass().getSimpleName(), "Cleaning data files for table: " + config.getTableName());
 
     Stream<Pair<String, CleanFileInfo>> filesToBeDeletedPerPartition =
         cleanerPlan.getFilePathsToBeDeletedPerPartition().entrySet().stream()
@@ -159,6 +159,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     LOG.info("***--- metaclient partitions to be deleted: " + partitionsToBeDeleted.size());
     if (config.parallelizePartitionCleaning()) {
       LOG.info("***--- Parallelizing partition deletes");
+      context.setJobStatus(this.getClass().getSimpleName(), "Cleaning partitions for table: " + config.getTableName());
       context.foreach(
           partitionsToBeDeleted,
           partitionPath -> deletePartitionsFunc(partitionPath, table),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -160,9 +160,9 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     if (config.parallelizePartitionCleaning()) {
       LOG.info("***--- Parallelizing partition deletes");
       context.foreach(
-              partitionsToBeDeleted,
-              partitionPath -> deletePartitionsFunc(partitionPath, table),
-              cleanerParallelism);
+          partitionsToBeDeleted,
+          partitionPath -> deletePartitionsFunc(partitionPath, table),
+          cleanerParallelism);
     } else {
       LOG.info("***--- Processing partition deletes on driver");
       partitionsToBeDeleted.forEach(entry -> {
@@ -176,9 +176,8 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         }
       });
     }
-    ;
 
-    // Return PartitionCleanStat for each partition passed.
+      // Return PartitionCleanStat for each partition passed.
     return cleanerPlan.getFilePathsToBeDeletedPerPartition().keySet().stream().map(partitionPath -> {
       PartitionCleanStat partitionCleanStat = partitionCleanStatsMap.containsKey(partitionPath)
           ? partitionCleanStatsMap.get(partitionPath)
@@ -211,7 +210,6 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     } catch (IOException e) {
       LOG.warn("Partition deletion failed " + path);
     }
-    ;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -150,8 +150,8 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
             iterator -> deleteFilesFunc(iterator, table), PartitionCleanStat::merge, cleanerParallelism);
 
     LOG.info("Collecting cleaner stats");
-      Map<String, PartitionCleanStat> partitionCleanStatsMap = partitionCleanStats
-        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    Map<String, PartitionCleanStat> partitionCleanStatsMap = partitionCleanStats
+            .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     List<String> partitionsToBeDeleted = table.getMetaClient().getTableConfig().isTablePartitioned() && cleanerPlan.getPartitionsToBeDeleted() != null
         ? cleanerPlan.getPartitionsToBeDeleted()
@@ -175,7 +175,8 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           LOG.warn("Partition deletion failed " + entry);
         }
       });
-    };
+    }
+    ;
 
     // Return PartitionCleanStat for each partition passed.
     return cleanerPlan.getFilePathsToBeDeletedPerPartition().keySet().stream().map(partitionPath -> {
@@ -201,15 +202,16 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     }).collect(Collectors.toList());
   }
 
-  private void deletePartitionsFunc(String path, HoodieTable<T,I,K,O> table) {
+  private void deletePartitionsFunc(String path, HoodieTable<T, I, K, O> table) {
     try {
-        if (!isNullOrEmpty(path)) {
-          deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
-                  table.getMetaClient().getBasePath() + "/" + path);
-        }
-      } catch (IOException e) {
-        LOG.warn("Partition deletion failed " + path);
-      };
+      if (!isNullOrEmpty(path)) {
+        deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
+                table.getMetaClient().getBasePath() + "/" + path);
+      }
+    } catch (IOException e) {
+      LOG.warn("Partition deletion failed " + path);
+    }
+    ;
   }
 
   /**
@@ -273,6 +275,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     // If there are inflight(failed) or previously requested clean operation, first perform them
     List<HoodieInstant> pendingCleanInstants = table.getCleanTimeline()
         .filterInflightsAndRequested().getInstants();
+    LOG.info("***--- found {} pending clean instants.", pendingCleanInstants.size());
     if (pendingCleanInstants.size() > 0) {
       // try to clean old history schema.
       try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
@@ -74,7 +73,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     this.skipLocking = skipLocking;
   }
 
-  private static Boolean deleteFileAndGetResult(FileSystem fs, String deletePathStr, Integer count) throws IOException {
+  private static Boolean deleteFileAndGetResult(FileSystem fs, String deletePathStr) throws IOException {
     Path deletePath = new Path(deletePathStr);
     LOG.info("***--- Working on delete path :" + deletePath);
     try {
@@ -89,9 +88,6 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           LOG.info("***--- Already cleaned up file at path :" + deletePath);
         }
       }
-      if (count % 1000 == 0) {
-        LOG.info("***--- delete paths processed: " + count);
-      }
       return deleteResult;
     } catch (FileNotFoundException fio) {
       // With cleanPlan being used for retried cleaning operations, its possible to clean a file twice
@@ -103,16 +99,14 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     Map<String, PartitionCleanStat> partitionCleanStatMap = new HashMap<>();
     FileSystem fs = (FileSystem) table.getStorage().getFileSystem();
 
-    AtomicInteger count = new AtomicInteger(0);
     cleanFileInfo.forEachRemaining(partitionDelFileTuple -> {
-      count.incrementAndGet();
       String partitionPath = partitionDelFileTuple.getLeft();
       LOG.info("***--- Partition path: " + partitionPath);
       Path deletePath = new Path(partitionDelFileTuple.getRight().getFilePath());
       String deletePathStr = deletePath.toString();
       boolean deletedFileResult = false;
       try {
-        deletedFileResult = deleteFileAndGetResult(fs, deletePathStr, count.get());
+        deletedFileResult = deleteFileAndGetResult(fs, deletePathStr);
       } catch (IOException e) {
         LOG.error("Delete file failed: " + deletePathStr, e);
       }
@@ -162,19 +156,26 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     List<String> partitionsToBeDeleted = table.getMetaClient().getTableConfig().isTablePartitioned() && cleanerPlan.getPartitionsToBeDeleted() != null
         ? cleanerPlan.getPartitionsToBeDeleted()
         : new ArrayList<>();
-    AtomicInteger count = new AtomicInteger(0);
     LOG.info("***--- metaclient partitions to be deleted: " + partitionsToBeDeleted.size());
-    partitionsToBeDeleted.forEach(entry -> {
-      try {
-        if (!isNullOrEmpty(entry)) {
-          count.incrementAndGet();
-          deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
-              table.getMetaClient().getBasePath() + "/" + entry, count.get());
+    if (config.parallelizePartitionCleaning()) {
+      LOG.info("***--- Parallelizing partition deletes");
+      context.foreach(
+              partitionsToBeDeleted,
+              partitionPath -> deletePartitionsFunc(partitionPath, table),
+              cleanerParallelism);
+    } else {
+      LOG.info("***--- Processing partition deletes on driver");
+      partitionsToBeDeleted.forEach(entry -> {
+        try {
+          if (!isNullOrEmpty(entry)) {
+            deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
+                    table.getMetaClient().getBasePath() + "/" + entry);
+          }
+        } catch (IOException e) {
+          LOG.warn("Partition deletion failed " + entry);
         }
-      } catch (IOException e) {
-        LOG.warn("Partition deletion failed " + entry);
-      }
-    });
+      });
+    };
 
     // Return PartitionCleanStat for each partition passed.
     return cleanerPlan.getFilePathsToBeDeletedPerPartition().keySet().stream().map(partitionPath -> {
@@ -200,6 +201,16 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     }).collect(Collectors.toList());
   }
 
+  private void deletePartitionsFunc(String path, HoodieTable<T,I,K,O> table) {
+    try {
+        if (!isNullOrEmpty(path)) {
+          deleteFileAndGetResult((FileSystem) table.getStorage().getFileSystem(),
+                  table.getMetaClient().getBasePath() + "/" + path);
+        }
+      } catch (IOException e) {
+        LOG.warn("Partition deletion failed " + path);
+      };
+  }
 
   /**
    * Executes the Cleaner plan stored in the instant metadata.

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.common;
 
+import org.apache.hudi.client.HoodieSparkClusteringClient;
 import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.common.data.HoodieAccumulator;
 import org.apache.hudi.common.data.HoodieData;
@@ -56,6 +57,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 
 /**
@@ -63,7 +66,7 @@ import scala.Tuple2;
  */
 @ThreadSafe
 public class HoodieSparkEngineContext extends HoodieEngineContext {
-
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieSparkEngineContext.class);
   private final JavaSparkContext javaSparkContext;
   private final SQLContext sqlContext;
   private final Map<HoodieDataCacheKey, List<Integer>> cachedRddIds = new HashMap<>();
@@ -128,7 +131,9 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   public <I, K, V> Stream<ImmutablePair<K, V>> mapPartitionsToPairAndReduceByKey(
       Stream<I> data, SerializablePairFlatMapFunction<Iterator<I>, K, V> flatMapToPairFunc,
       SerializableBiFunction<V, V, V> reduceFunc, int parallelism) {
-    return javaSparkContext.parallelize(data.collect(Collectors.toList()), parallelism)
+    List<I> pathsToProcess = data.collect(Collectors.toList());
+    LOG.info("***--- There are " + pathsToProcess.size() + " partition paths to process");
+    return javaSparkContext.parallelize(pathsToProcess, parallelism)
         .mapPartitionsToPair((PairFlatMapFunction<Iterator<I>, K, V>) iterator ->
             flatMapToPairFunc.call(iterator).collect(Collectors.toList()).stream()
                 .map(e -> new Tuple2<>(e.getKey(), e.getValue())).iterator()

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client.common;
 
-import org.apache.hudi.client.HoodieSparkClusteringClient;
 import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.common.data.HoodieAccumulator;
 import org.apache.hudi.common.data.HoodieData;


### PR DESCRIPTION
If there are any partitions to be deleted in the clean plan, setting `hoodie.cleaner.parallelize_partition_cleaning` to true will parallelize this deletion. Otherwise the deletes will be processed by the driver.
