### PR TITLE
Versioning hudi heap-fork

### DIFF
--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hudi-aws</artifactId>
-    <version>0.15.0-heap-fork</version>
+    <version>${heapfork.label}-${heapfork.version}</version>
 
     <name>hudi-aws</name>
     <packaging>jar</packaging>

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -105,7 +105,9 @@ public class TimelineUtils {
             .map(partition -> new AbstractMap.SimpleEntry<>(partition, pair.getLeft().getTimestamp()))
         ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replace) -> replace));
     // cleaner could delete a partition when there are no active filegroups in the partition
-    HoodieTimeline cleanerTimeline = TimelineUtils.getCleanerTimelineAfter(metaClient, lastCommitTimeSynced.get(), lastCommitCompletionTimeSynced).filterCompletedInstants();
+    HoodieTimeline cleanerTimeline = lastCommitTimeSynced.isPresent()
+        ? TimelineUtils.getCleanerTimelineAfter(metaClient, lastCommitTimeSynced.get(), lastCommitCompletionTimeSynced).filterCompletedInstants()
+        : metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
     cleanerTimeline.getInstantsAsStream()
         .forEach(instant -> {
           try {

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hudi-hive-sync-bundle</artifactId>
-  <version>0.15.0-heap-fork</version>
+  <version>${heapfork.label}-${heapfork.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hudi-spark${sparkbundle.version}-bundle_${scala.binary.version}</artifactId>
-  <version>0.15.0-heap-fork</version>
+  <version>${heapfork.label}-${heapfork.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hudi-utilities-bundle_${scala.binary.version}</artifactId>
-  <version>0.15.0-heap-fork</version>
+  <version>${heapfork.label}-${heapfork.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,8 @@
     <springboot.version>2.7.3</springboot.version>
     <spring.shell.version>2.1.1</spring.shell.version>
     <snappy.version>1.1.8.3</snappy.version>
+    <heapfork.label>0.15.0-heap-fork</heapfork.label>
+    <heapfork.version>0.1-SNAPSHOT</heapfork.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Versioning for hudi heap-fork. Start out with version `0.15.0-heap-fork-0.1-SNAPSHOT` making next official release  `0.15.0-heap-fork-0.1`.

Also includes a failing test fix.
