### PR TITLE
[DE-27260] fix spark catalyst incompatibility

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -141,7 +141,7 @@ object CreateHoodieTableCommand {
       .getOrElse(catalog.getCurrentDatabase))
 
     val newTableIdentifier = table.identifier
-      .copy(table = tableName, database = Some(newDatabaseName))
+      .copy(table = tableName, database = Some(newDatabaseName), None)
 
     val partitionColumnNames = hoodieCatalogTable.partitionSchema.map(_.name)
     // Remove some properties should not be used;append pk, preCombineKey, type to the properties of table


### PR DESCRIPTION
Spark 3.4 modified the interface of `TableIdentifier` class with a new optional `catalog` parameter: https://github.com/apache/spark/commit/f8a377527c8a091371d4ff8406c526d3d6d28308. Update the `CreateHoodieTableCommand` to work with the new interface.