### PR TITLE
[DE-27803] fix hudi-cli SparkMain YARN application status

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -253,7 +253,12 @@ public class SparkMain {
     } finally {
       jsc.stop();
     }
-    System.exit(returnCode);
+    if (!jsc.master().equals("yarn")) {
+      System.exit(returnCode);
+    }
+    if (returnCode != 0) {
+      throw new Error("Command failed with exitCode: " + returnCode);
+    }
   }
 
   protected static void clean(JavaSparkContext jsc, String basePath, String propsFilePath,


### PR DESCRIPTION
The hudi-cli `SparkMain` command is always marked `FAILED` in yarn even if there are no errors. When running Spark in YARN, the application shouldn't call `System.exit` directly: https://github.com/apache/spark/blob/v3.3.0/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala#L253-L255