### PR TITLE
Liz/0.2 snapshot

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -842,15 +842,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       return null;
     }
 
-    // Deterministic order so batchIndex is stable across resume attempts that
-    // recompute the partition list.
-    Collections.sort(fullPartitionList);
-
     int batchSize = config.getCleanerPlanPartitionsBatchSize();
-    List<List<String>> chunks = new ArrayList<>();
-    for (int i = 0; i < fullPartitionList.size(); i += batchSize) {
-      chunks.add(fullPartitionList.subList(i, Math.min(i + batchSize, fullPartitionList.size())));
-    }
+    List<List<String>> chunks = chunkForBatchedClean(fullPartitionList, batchSize);
     int totalBatches = chunks.size();
     String targetEarliestCommit = earliestInstant.map(HoodieInstant::getTimestamp).orElse("");
 
@@ -933,28 +926,72 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
           continue;
         }
         HoodieCleanMetadata meta = TimelineMetadataUtils.deserializeHoodieCleanMetadata(details.get());
-        Map<String, String> extra = meta.getExtraMetadata();
-        if (extra == null) {
-          continue;
+        Option<Integer> idx = parseCompletedBatchIndex(meta.getExtraMetadata(), targetEarliestCommit, totalBatches);
+        if (idx.isPresent()) {
+          done.add(idx.get());
         }
-        String tgt = extra.get(BATCH_TARGET_EARLIEST_COMMIT_KEY);
-        String tot = extra.get(BATCH_TOTAL_BATCHES_KEY);
-        String idx = extra.get(BATCH_INDEX_KEY);
-        if (tgt == null || tot == null || idx == null) {
-          continue;
-        }
-        if (!tgt.equals(targetEarliestCommit)) {
-          continue;
-        }
-        if (Integer.parseInt(tot) != totalBatches) {
-          continue;
-        }
-        done.add(Integer.parseInt(idx));
       } catch (Exception e) {
         LOG.warn("Batched clean: failed to inspect completed clean instant {} for resume; ignoring.", instant, e);
       }
     }
     return done;
+  }
+
+  /**
+   * Deterministically chunk the partition list into batches of at most
+   * {@code batchSize}. Sorts by natural string order so a re-invoked
+   * (post-crash) job produces the same chunks and can align on
+   * {@code batchIndex} against earlier completions.
+   *
+   * <p>Package-private for unit testing.
+   *
+   * @throws IllegalArgumentException if batchSize is not positive.
+   */
+  static List<List<String>> chunkForBatchedClean(List<String> partitions, int batchSize) {
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive, got " + batchSize);
+    }
+    List<String> sorted = new ArrayList<>(partitions);
+    Collections.sort(sorted);
+    List<List<String>> chunks = new ArrayList<>();
+    for (int i = 0; i < sorted.size(); i += batchSize) {
+      chunks.add(new ArrayList<>(sorted.subList(i, Math.min(i + batchSize, sorted.size()))));
+    }
+    return chunks;
+  }
+
+  /**
+   * Parse a completed clean instant's extraMetadata to determine whether it
+   * belongs to a paginated run identified by {@code targetEarliestCommit} +
+   * {@code totalBatches}, and if so return its {@code batchIndex}. Returns
+   * empty for legacy (non-batched) instants, instants from other runs, and
+   * instants whose bookkeeping keys don't parse.
+   *
+   * <p>Package-private for unit testing.
+   */
+  static Option<Integer> parseCompletedBatchIndex(Map<String, String> extra,
+                                                  String targetEarliestCommit,
+                                                  int totalBatches) {
+    if (extra == null) {
+      return Option.empty();
+    }
+    String tgt = extra.get(BATCH_TARGET_EARLIEST_COMMIT_KEY);
+    String tot = extra.get(BATCH_TOTAL_BATCHES_KEY);
+    String idx = extra.get(BATCH_INDEX_KEY);
+    if (tgt == null || tot == null || idx == null) {
+      return Option.empty();
+    }
+    if (!tgt.equals(targetEarliestCommit)) {
+      return Option.empty();
+    }
+    try {
+      if (Integer.parseInt(tot) != totalBatches) {
+        return Option.empty();
+      }
+      return Option.of(Integer.parseInt(idx));
+    } catch (NumberFormatException e) {
+      return Option.empty();
+    }
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -42,6 +42,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -60,6 +61,9 @@ import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
+import org.apache.hudi.table.action.clean.CleanActionExecutor;
+import org.apache.hudi.table.action.clean.CleanPlanActionExecutor;
+import org.apache.hudi.table.action.clean.CleanPlanner;
 import org.apache.hudi.table.action.compact.CompactHelpers;
 import org.apache.hudi.table.action.rollback.RollbackUtils;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
@@ -72,12 +76,15 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -744,6 +751,10 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       return null;
     }
 
+    if (config.getCleanerPlanPartitionsBatchSize() > 0) {
+      return cleanInBatches(cleanInstantTime, timerContext);
+    }
+
     HoodieTable table = createTable(config, hadoopConf);
     if (config.allowMultipleCleans() || !table.getActiveTimeline().getCleanerTimeline().filterInflightsAndRequested().firstInstant().isPresent()) {
       LOG.info("Cleaner started");
@@ -770,6 +781,180 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     }
     releaseResources(cleanInstantTime);
     return metadata;
+  }
+
+  // Extra-metadata keys tagging each batch's clean instant. Kept in sync
+  // across every batch of one logical paginated clean run so a re-invoked
+  // (post-crash) job can identify which batch indices have already
+  // completed by scanning completed .clean instants.
+  static final String BATCH_TARGET_EARLIEST_COMMIT_KEY = "hoodie.clean.batch.targetEarliestCommitToRetain";
+  static final String BATCH_TOTAL_BATCHES_KEY = "hoodie.clean.batch.totalBatches";
+  static final String BATCH_INDEX_KEY = "hoodie.clean.batch.batchIndex";
+
+  /**
+   * Paginated variant of {@link #clean(String, boolean)}, active when
+   * {@code hoodie.clean.plan.partitions.batch.size > 0}. Splits the full
+   * partition list into deterministic chunks and drives each chunk through
+   * an independent request/inflight/complete clean-instant lifecycle. All
+   * chunks in one run share the same {@code earliestCommitToRetain} so that
+   * per-partition delete decisions in {@link CleanPlanner#getDeletePaths}
+   * stay consistent across batches (see {@link CleanPlanActionExecutor.BatchOverride}).
+   * <p>
+   * Resume: if a prior invocation crashed partway, completed batches for the
+   * same {@code targetEarliestCommitToRetain}+{@code totalBatches} are
+   * detected from the completed clean timeline's extraMetadata and skipped;
+   * any straggling pending/inflight clean instant is finished first via
+   * {@link CleanActionExecutor} before the resumed loop begins.
+   */
+  @Nullable
+  private HoodieCleanMetadata cleanInBatches(String cleanInstantTime, Timer.Context timerContext) throws HoodieIOException {
+    HoodieTable table = createTable(config, hadoopConf);
+
+    // If a prior crashed run left any pending .clean.requested/.clean.inflight
+    // behind, finish them first so their completions land on the timeline and
+    // are visible to the resume-detection scan below.
+    if (table.getActiveTimeline().getCleanerTimeline().filterInflightsAndRequested().firstInstant().isPresent()) {
+      LOG.info("Finishing pending clean instants from a prior run before starting batched clean.");
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      CleanActionExecutor finishPending = new CleanActionExecutor(context, config, table, cleanInstantTime);
+      finishPending.execute();
+      table.getMetaClient().reloadActiveTimeline();
+    }
+
+    // Compute the retention boundary and full partition list ONCE. Both are
+    // pinned across every batch in this run (BatchOverride) so per-partition
+    // delete decisions stay consistent.
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    CleanPlanner planner = new CleanPlanner(context, table, config);
+    Option<HoodieInstant> earliestInstant = planner.getEarliestCommitToRetain();
+    List<String> fullPartitionList;
+    try {
+      @SuppressWarnings("unchecked")
+      List<String> raw = planner.getPartitionPathsToClean(earliestInstant);
+      fullPartitionList = new ArrayList<>(raw);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to list partitions for batched clean", e);
+    }
+
+    if (fullPartitionList.isEmpty()) {
+      LOG.info("Batched clean: nothing to clean. Table is already clean.");
+      releaseResources(cleanInstantTime);
+      return null;
+    }
+
+    // Deterministic order so batchIndex is stable across resume attempts that
+    // recompute the partition list.
+    Collections.sort(fullPartitionList);
+
+    int batchSize = config.getCleanerPlanPartitionsBatchSize();
+    List<List<String>> chunks = new ArrayList<>();
+    for (int i = 0; i < fullPartitionList.size(); i += batchSize) {
+      chunks.add(fullPartitionList.subList(i, Math.min(i + batchSize, fullPartitionList.size())));
+    }
+    int totalBatches = chunks.size();
+    String targetEarliestCommit = earliestInstant.map(HoodieInstant::getTimestamp).orElse("");
+
+    LOG.info("Batched clean: {} partitions -> {} batches of up to {}, targetEarliestCommitToRetain={}",
+        fullPartitionList.size(), totalBatches, batchSize, targetEarliestCommit);
+
+    Set<Integer> alreadyDone = findCompletedBatchIndices(table, targetEarliestCommit, totalBatches);
+    if (!alreadyDone.isEmpty()) {
+      LOG.info("Batched clean: resuming; {} batches already complete: {}",
+          alreadyDone.size(), new TreeSet<>(alreadyDone));
+    }
+
+    HoodieCleanMetadata lastMetadata = null;
+    for (int i = 0; i < totalBatches; i++) {
+      if (alreadyDone.contains(i)) {
+        continue;
+      }
+      Map<String, String> batchMeta = new HashMap<>();
+      batchMeta.put(BATCH_TARGET_EARLIEST_COMMIT_KEY, targetEarliestCommit);
+      batchMeta.put(BATCH_TOTAL_BATCHES_KEY, String.valueOf(totalBatches));
+      batchMeta.put(BATCH_INDEX_KEY, String.valueOf(i));
+
+      String batchInstantTime = HoodieActiveTimeline.createNewInstantTime();
+      LOG.info("Batched clean: batch {}/{} (instantTime={}, partitions={})",
+          i + 1, totalBatches, batchInstantTime, chunks.get(i).size());
+
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      CleanPlanActionExecutor<?, ?, ?, ?> planExecutor = new CleanPlanActionExecutor(
+          context, config, table, batchInstantTime, Option.of(batchMeta),
+          Option.of(new CleanPlanActionExecutor.BatchOverride(chunks.get(i), earliestInstant)));
+      // Call requestClean directly (bypassing execute()) so per-batch invocations skip
+      // the numCommits-since-last-clean trigger gate, which would return false for
+      // batches 2..N (the just-completed batch 1 is itself the "last clean").
+      Option<HoodieCleanerPlan> plan = planExecutor.requestClean(batchInstantTime);
+      if (!plan.isPresent()) {
+        // No files to delete in this chunk. Still record it as "done" for this
+        // logical run so resume doesn't retry it. Cheapest way: skip and let
+        // the next run's completed-scan see it missing; the batch will be
+        // re-attempted and again produce nothing. Not worth a synthetic
+        // instant just to record the no-op.
+        LOG.info("Batched clean: batch {}/{} produced no plan (nothing to delete in these partitions).",
+            i + 1, totalBatches);
+        continue;
+      }
+
+      table.getMetaClient().reloadActiveTimeline();
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      CleanActionExecutor batchExecutor = new CleanActionExecutor(context, config, table, batchInstantTime);
+      HoodieCleanMetadata metadata = (HoodieCleanMetadata) batchExecutor.execute();
+      table.getMetaClient().reloadActiveTimeline();
+      if (metadata != null) {
+        lastMetadata = metadata;
+        if (timerContext != null) {
+          long durationMs = metrics.getDurationInMs(timerContext.stop());
+          metrics.updateCleanMetrics(durationMs, metadata.getTotalFilesDeleted());
+        }
+        LOG.info("Batched clean: batch {}/{} complete. filesDeleted={} earliestCommitToRetain={}",
+            i + 1, totalBatches, metadata.getTotalFilesDeleted(), metadata.getEarliestCommitToRetain());
+      }
+    }
+
+    releaseResources(cleanInstantTime);
+    return lastMetadata;
+  }
+
+  /**
+   * Scans completed .clean instants and collects the {@link #BATCH_INDEX_KEY}
+   * values whose extraMetadata matches the given targetEarliestCommitToRetain
+   * and totalBatches. Batches whose extraMetadata does not identify them as
+   * part of this logical run are ignored (they belong to a different run or
+   * to the legacy non-batched path).
+   */
+  private Set<Integer> findCompletedBatchIndices(HoodieTable table, String targetEarliestCommit, int totalBatches) {
+    Set<Integer> done = new HashSet<>();
+    List<HoodieInstant> completed = table.getActiveTimeline().getCleanerTimeline().filterCompletedInstants().getInstants();
+    for (HoodieInstant instant : completed) {
+      try {
+        Option<byte[]> details = table.getActiveTimeline().getInstantDetails(instant);
+        if (!details.isPresent()) {
+          continue;
+        }
+        HoodieCleanMetadata meta = TimelineMetadataUtils.deserializeHoodieCleanMetadata(details.get());
+        Map<String, String> extra = meta.getExtraMetadata();
+        if (extra == null) {
+          continue;
+        }
+        String tgt = extra.get(BATCH_TARGET_EARLIEST_COMMIT_KEY);
+        String tot = extra.get(BATCH_TOTAL_BATCHES_KEY);
+        String idx = extra.get(BATCH_INDEX_KEY);
+        if (tgt == null || tot == null || idx == null) {
+          continue;
+        }
+        if (!tgt.equals(targetEarliestCommit)) {
+          continue;
+        }
+        if (Integer.parseInt(tot) != totalBatches) {
+          continue;
+        }
+        done.add(Integer.parseInt(idx));
+      } catch (Exception e) {
+        LOG.warn("Batched clean: failed to inspect completed clean instant {} for resume; ignoring.", instant, e);
+      }
+    }
+    return done;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -164,6 +164,17 @@ public class HoodieCleanConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation(HoodieFailedWritesCleaningPolicy.class);
 
+  public static final ConfigProperty<Integer> CLEANER_PLAN_PARTITIONS_BATCH_SIZE = ConfigProperty
+      .key("hoodie.clean.plan.partitions.batch.size")
+      .defaultValue(-1)
+      .markAdvanced()
+      .sinceVersion("0.15.0-heap-fork")
+      .withDocumentation("When set to a positive value, paginates a single cleaner invocation "
+          + "into multiple internally-batched clean instants, each covering at most this many "
+          + "partitions, to avoid building an oversized single HoodieCleanerPlan. Each batch "
+          + "shares the same earliestCommitToRetain boundary. Default (-1) preserves legacy "
+          + "single-plan behavior.");
+
   public static final ConfigProperty<String> CLEANER_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.cleaner.parallelism")
       .defaultValue("200")
@@ -347,6 +358,11 @@ public class HoodieCleanConfig extends HoodieConfig {
 
     public HoodieCleanConfig.Builder withCleanerParallelism(int cleanerParallelism) {
       cleanConfig.setValue(CLEANER_PARALLELISM_VALUE, String.valueOf(cleanerParallelism));
+      return this;
+    }
+
+    public HoodieCleanConfig.Builder withCleanerPlanPartitionsBatchSize(int batchSize) {
+      cleanConfig.setValue(CLEANER_PLAN_PARTITIONS_BATCH_SIZE, String.valueOf(batchSize));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1547,6 +1547,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieCleanConfig.CLEANER_PARALLELISM_VALUE);
   }
 
+  public int getCleanerPlanPartitionsBatchSize() {
+    return getInt(HoodieCleanConfig.CLEANER_PLAN_PARTITIONS_BATCH_SIZE);
+  }
+
   public int getCleaningMaxCommits() {
     return getInt(HoodieCleanConfig.CLEAN_MAX_COMMITS);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -56,14 +56,44 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
 
   private static final Logger LOG = LoggerFactory.getLogger(CleanPlanActionExecutor.class);
   private final Option<Map<String, String>> extraMetadata;
+  private final Option<BatchOverride> batchOverride;
+
+  /**
+   * Overrides used by the paginated-clean orchestrator to pin the retention
+   * boundary and the partition scope for a single batch. Both must move
+   * together: {@link CleanPlanner#getDeletePaths(String, Option)} takes
+   * {@code earliestInstant} per partition, so letting the executor recompute
+   * the boundary while the orchestrator supplies a fixed partition slice
+   * would silently break the "same earliestCommitToRetain across all
+   * batches" invariant.
+   */
+  public static final class BatchOverride {
+    final List<String> partitions;
+    final Option<HoodieInstant> earliestInstant;
+
+    public BatchOverride(List<String> partitions, Option<HoodieInstant> earliestInstant) {
+      this.partitions = partitions;
+      this.earliestInstant = earliestInstant;
+    }
+  }
 
   public CleanPlanActionExecutor(HoodieEngineContext context,
                                  HoodieWriteConfig config,
                                  HoodieTable<T, I, K, O> table,
                                  String instantTime,
                                  Option<Map<String, String>> extraMetadata) {
+    this(context, config, table, instantTime, extraMetadata, Option.empty());
+  }
+
+  public CleanPlanActionExecutor(HoodieEngineContext context,
+                                 HoodieWriteConfig config,
+                                 HoodieTable<T, I, K, O> table,
+                                 String instantTime,
+                                 Option<Map<String, String>> extraMetadata,
+                                 Option<BatchOverride> batchOverride) {
     super(context, config, table, instantTime);
     this.extraMetadata = extraMetadata;
+    this.batchOverride = batchOverride;
   }
 
   private int getCommitsSinceLastCleaning() {
@@ -106,9 +136,16 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
   HoodieCleanerPlan requestClean(HoodieEngineContext context) {
     try {
       CleanPlanner<T, I, K, O> planner = new CleanPlanner<>(context, table, config);
-      Option<HoodieInstant> earliestInstant = planner.getEarliestCommitToRetain();
+      // When batchOverride is present, the orchestrator pins earliestInstant and the
+      // partition slice so every batch in a paginated run stays anchored to the same
+      // retention boundary (see BatchOverride javadoc).
+      Option<HoodieInstant> earliestInstant = batchOverride.isPresent()
+          ? batchOverride.get().earliestInstant
+          : planner.getEarliestCommitToRetain();
       context.setJobStatus(this.getClass().getSimpleName(), "Obtaining list of partitions to be cleaned: " + config.getTableName());
-      List<String> partitionsToClean = planner.getPartitionPathsToClean(earliestInstant);
+      List<String> partitionsToClean = batchOverride.isPresent()
+          ? batchOverride.get().partitions
+          : planner.getPartitionPathsToClean(earliestInstant);
 
       if (partitionsToClean.isEmpty()) {
         LOG.info("Nothing to clean here. It is already clean");
@@ -149,28 +186,36 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
           .map(x -> new HoodieActionInstant(x.getTimestamp(), x.getAction(), x.getState().name())).orElse(null),
           planner.getLastCompletedCommitTimestamp(),
           config.getCleanerPolicy().name(), Collections.emptyMap(),
-          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete, prepareExtraMetadata(planner.getSavepointedTimestamps()));
+          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete,
+          prepareExtraMetadata(planner.getSavepointedTimestamps(), extraMetadata));
     } catch (IOException e) {
       throw new HoodieIOException("Failed to schedule clean operation", e);
     }
   }
 
-  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps) {
-    if (savepointedTimestamps.isEmpty()) {
-      return Collections.emptyMap();
-    } else {
-      return Collections.singletonMap(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
+  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps,
+                                                   Option<Map<String, String>> callerExtras) {
+    Map<String, String> merged = new HashMap<>();
+    if (!savepointedTimestamps.isEmpty()) {
+      merged.put(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
     }
+    callerExtras.ifPresent(merged::putAll);
+    return merged.isEmpty() ? Collections.emptyMap() : merged;
   }
 
   /**
    * Creates a Cleaner plan if there are files to be cleaned and stores them in instant file.
    * Cleaner Plan contains absolute file paths.
    *
+   * <p>Callable directly by orchestrators (e.g. the paginated-clean loop in
+   * {@code BaseHoodieTableServiceClient.cleanInBatches}) that manage their
+   * own instant lifecycle and bypass the {@link #execute()}
+   * {@code needsCleaning} trigger check per-batch.
+   *
    * @param startCleanTime Cleaner Instant Time
    * @return Cleaner Plan if generated
    */
-  protected Option<HoodieCleanerPlan> requestClean(String startCleanTime) {
+  public Option<HoodieCleanerPlan> requestClean(String startCleanTime) {
     final HoodieCleanerPlan cleanerPlan = requestClean(context);
     Option<HoodieCleanerPlan> option = Option.empty();
     if (nonEmpty(cleanerPlan.getFilePathsToBeDeletedPerPartition())

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBatchedCleanHelpers.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBatchedCleanHelpers.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the pure helpers backing the paginated-clean orchestration in
+ * {@link BaseHoodieTableServiceClient}. Kept off the mock-heavy path so
+ * chunking / resume-parsing invariants are exercised as fast pure-Java
+ * assertions.
+ */
+public class TestBatchedCleanHelpers {
+
+  // -----------------------------------------------------------------
+  // chunkForBatchedClean
+  // -----------------------------------------------------------------
+
+  @Test
+  void chunk_emptyList_returnsEmpty() {
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(
+        Collections.emptyList(), 5);
+    assertTrue(chunks.isEmpty(), "no chunks for empty partition list");
+  }
+
+  @Test
+  void chunk_sizeSmallerThanBatch_returnsSingleChunk() {
+    List<String> partitions = Arrays.asList("a", "b", "c");
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 5);
+    assertEquals(1, chunks.size());
+    assertEquals(Arrays.asList("a", "b", "c"), chunks.get(0));
+  }
+
+  @Test
+  void chunk_sizeEqualToBatch_returnsSingleFullChunk() {
+    List<String> partitions = Arrays.asList("a", "b", "c");
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 3);
+    assertEquals(1, chunks.size());
+    assertEquals(3, chunks.get(0).size());
+  }
+
+  @Test
+  void chunk_cleanMultipleOfBatchSize_returnsEvenChunks() {
+    List<String> partitions = Arrays.asList("a", "b", "c", "d", "e", "f");
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 2);
+    assertEquals(3, chunks.size());
+    for (List<String> chunk : chunks) {
+      assertEquals(2, chunk.size());
+    }
+  }
+
+  @Test
+  void chunk_fractionalRemainder_lastChunkSmaller() {
+    List<String> partitions = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 3);
+    assertEquals(3, chunks.size());
+    assertEquals(3, chunks.get(0).size());
+    assertEquals(3, chunks.get(1).size());
+    assertEquals(1, chunks.get(2).size(), "trailing partial batch preserved");
+  }
+
+  @Test
+  void chunk_sortsBeforeChunking_soRestartsProduceSameLayout() {
+    // Reverse-sorted input — deterministic chunking must sort first so that
+    // a resume attempt aligns on batchIndex regardless of input order from
+    // the (possibly re-run) partition listing.
+    List<String> partitions = Arrays.asList("p9", "p8", "p7", "p6", "p5", "p4", "p3", "p2", "p1", "p0");
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 4);
+    assertEquals(3, chunks.size());
+    assertEquals(Arrays.asList("p0", "p1", "p2", "p3"), chunks.get(0));
+    assertEquals(Arrays.asList("p4", "p5", "p6", "p7"), chunks.get(1));
+    assertEquals(Arrays.asList("p8", "p9"), chunks.get(2));
+  }
+
+  @Test
+  void chunk_doesNotMutateInput() {
+    List<String> partitions = new ArrayList<>(Arrays.asList("z", "a", "m"));
+    BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 2);
+    assertEquals(Arrays.asList("z", "a", "m"), partitions,
+        "caller's list must not be mutated (sorted in place)");
+  }
+
+  @Test
+  void chunk_batchSizeZero_rejects() {
+    assertThrows(IllegalArgumentException.class,
+        () -> BaseHoodieTableServiceClient.chunkForBatchedClean(Arrays.asList("a"), 0));
+  }
+
+  @Test
+  void chunk_batchSizeNegative_rejects() {
+    assertThrows(IllegalArgumentException.class,
+        () -> BaseHoodieTableServiceClient.chunkForBatchedClean(Arrays.asList("a"), -1));
+  }
+
+  // -----------------------------------------------------------------
+  // parseCompletedBatchIndex
+  // -----------------------------------------------------------------
+
+  @Test
+  void parse_nullExtraMetadata_returnsEmpty() {
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(null, "20260101010101", 10);
+    assertFalse(idx.isPresent(), "null extraMetadata => not a batched instant");
+  }
+
+  @Test
+  void parse_emptyExtraMetadata_returnsEmpty() {
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(new HashMap<>(), "20260101010101", 10);
+    assertFalse(idx.isPresent(), "no batch keys => not a batched instant");
+  }
+
+  @Test
+  void parse_missingIndex_returnsEmpty() {
+    Map<String, String> extra = new HashMap<>();
+    extra.put(BaseHoodieTableServiceClient.BATCH_TARGET_EARLIEST_COMMIT_KEY, "20260101010101");
+    extra.put(BaseHoodieTableServiceClient.BATCH_TOTAL_BATCHES_KEY, "10");
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 10);
+    assertFalse(idx.isPresent(), "missing batchIndex => not usable");
+  }
+
+  @Test
+  void parse_mismatchedTarget_returnsEmpty() {
+    Map<String, String> extra = matchingExtra("20260101010101", 10, 3);
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260201020202", 10);
+    assertFalse(idx.isPresent(), "different targetEarliestCommit => belongs to a different logical run");
+  }
+
+  @Test
+  void parse_mismatchedTotalBatches_returnsEmpty() {
+    Map<String, String> extra = matchingExtra("20260101010101", 10, 3);
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 12);
+    assertFalse(idx.isPresent(), "different totalBatches => the run was re-partitioned; can't reuse");
+  }
+
+  @Test
+  void parse_malformedTotal_returnsEmpty() {
+    Map<String, String> extra = matchingExtra("20260101010101", 10, 3);
+    extra.put(BaseHoodieTableServiceClient.BATCH_TOTAL_BATCHES_KEY, "not-a-number");
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 10);
+    assertFalse(idx.isPresent(), "malformed totalBatches => ignore rather than crash");
+  }
+
+  @Test
+  void parse_malformedIndex_returnsEmpty() {
+    Map<String, String> extra = matchingExtra("20260101010101", 10, 3);
+    extra.put(BaseHoodieTableServiceClient.BATCH_INDEX_KEY, "?");
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 10);
+    assertFalse(idx.isPresent(), "malformed batchIndex => ignore rather than crash");
+  }
+
+  @Test
+  void parse_matchingEntry_returnsIndex() {
+    Map<String, String> extra = matchingExtra("20260101010101", 10, 3);
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 10);
+    assertTrue(idx.isPresent());
+    assertEquals(3, idx.get().intValue());
+  }
+
+  @Test
+  void parse_legacyInstantWithSavepointedOnly_returnsEmpty() {
+    // A pre-batching completed clean might carry only SAVEPOINTED_TIMESTAMPS in
+    // extraMetadata. Resume scan must not mistake it for a batched instant.
+    Map<String, String> extra = new HashMap<>();
+    extra.put("hoodie.savepoint.timestamps", "20250101010101,20250201020202");
+    Option<Integer> idx = BaseHoodieTableServiceClient.parseCompletedBatchIndex(extra, "20260101010101", 10);
+    assertFalse(idx.isPresent());
+  }
+
+  // -----------------------------------------------------------------
+  // Combined: chunking + a simulated done-set produces the expected
+  // remaining slice — the whole spec's testing-plan point 1.
+  // -----------------------------------------------------------------
+
+  @Test
+  void combined_remainingChunksSkipDoneIndicesWithoutDuplicating() {
+    // 25 partitions, batchSize 3 -> 9 batches (last one size 1).
+    List<String> partitions = IntStream.range(0, 25).mapToObj(i -> String.format("p%02d", i)).collect(Collectors.toList());
+    List<List<String>> chunks = BaseHoodieTableServiceClient.chunkForBatchedClean(partitions, 3);
+    assertEquals(9, chunks.size());
+
+    // Simulate a prior crashed run that completed batches 0, 2, 5.
+    Set<Integer> done = new HashSet<>(Arrays.asList(0, 2, 5));
+
+    List<Integer> remaining = IntStream.range(0, chunks.size())
+        .filter(i -> !done.contains(i))
+        .boxed()
+        .collect(Collectors.toList());
+
+    assertEquals(Arrays.asList(1, 3, 4, 6, 7, 8), remaining,
+        "resume must skip completed batches and not duplicate any");
+
+    // Sanity: union of done + remaining covers all indices exactly once.
+    Set<Integer> union = new HashSet<>(done);
+    union.addAll(remaining);
+    assertEquals(chunks.size(), union.size(), "every batchIndex accounted for exactly once");
+  }
+
+  private static Map<String, String> matchingExtra(String target, int total, int index) {
+    Map<String, String> extra = new HashMap<>();
+    extra.put(BaseHoodieTableServiceClient.BATCH_TARGET_EARLIEST_COMMIT_KEY, target);
+    extra.put(BaseHoodieTableServiceClient.BATCH_TOTAL_BATCHES_KEY, String.valueOf(total));
+    extra.put(BaseHoodieTableServiceClient.BATCH_INDEX_KEY, String.valueOf(index));
+    return extra;
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/clean/TestCleanPlanActionExecutorBatchOverride.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/clean/TestCleanPlanActionExecutorBatchOverride.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.clean;
+
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Structural checks on {@link CleanPlanActionExecutor.BatchOverride}. The
+ * class exists specifically to keep {@code partitions} and
+ * {@code earliestInstant} pinned together so per-batch invocations of the
+ * paginated cleaner cannot accidentally drift on the retention boundary
+ * mid-run (see BatchOverride javadoc and the spec's correctness
+ * requirement).
+ *
+ * <p>End-to-end verification that {@code CleanPlanActionExecutor.requestClean}
+ * honors the override is best done via the integration-test path
+ * ({@code TestCleanPlanExecutor} in hudi-spark-client), where a real
+ * HoodieTable timeline is available.
+ */
+public class TestCleanPlanActionExecutorBatchOverride {
+
+  @Test
+  void batchOverride_storesFieldsAsProvided() {
+    List<String> partitions = Arrays.asList("2026/01/01", "2026/01/02", "2026/01/03");
+    HoodieInstant earliest = new HoodieInstant(
+        HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "20260101010101");
+
+    CleanPlanActionExecutor.BatchOverride override =
+        new CleanPlanActionExecutor.BatchOverride(partitions, Option.of(earliest));
+
+    assertSame(partitions, override.partitions,
+        "partitions must be stored by reference; the orchestrator owns the slice's lifetime");
+    assertNotNull(override.earliestInstant);
+    assertEquals("20260101010101", override.earliestInstant.get().getTimestamp());
+  }
+
+  @Test
+  void batchOverride_acceptsEmptyEarliestInstant() {
+    // Tables that have no earlier commits (e.g. brand-new tables) legitimately
+    // yield Option.empty from CleanPlanner.getEarliestCommitToRetain. The
+    // override must round-trip that unchanged so downstream logic still works.
+    CleanPlanActionExecutor.BatchOverride override =
+        new CleanPlanActionExecutor.BatchOverride(Arrays.asList("p0"), Option.empty());
+
+    assertNotNull(override.earliestInstant);
+    assertEquals(false, override.earliestInstant.isPresent());
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -53,18 +54,22 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -706,5 +711,162 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       assertFalse(testTable.baseFileExists(p0, firstCommitTs, file1P0C0));
       assertFalse(testTable.baseFileExists(p1, firstCommitTs, file1P1C0));
     }
+  }
+
+  /**
+   * With batch.size=-1 (default, disabled) the cleaner must still take the
+   * legacy single-instant path: exactly one .clean instant on the timeline,
+   * carrying none of the batching extraMetadata keys.
+   */
+  @Test
+  public void testCleanInBatchesDisabledPreservesLegacyPath() throws Exception {
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS)
+            .retainFileVersions(1)
+            .build())
+        .build();
+    seedTwoVersionsPerPartition(config, makePartitions(4));
+
+    runCleaner(config, 2, true);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    List<HoodieInstant> completed = metaClient.getActiveTimeline().getCleanerTimeline()
+        .filterCompletedInstants().getInstants();
+    assertEquals(1, completed.size(),
+        "Legacy (non-batched) clean must produce exactly one clean instant.");
+
+    Map<String, String> extra = CleanerUtils.getCleanerMetadata(metaClient, completed.get(0)).getExtraMetadata();
+    if (extra != null) {
+      assertNull(extra.get("hoodie.clean.batch.batchIndex"),
+          "Legacy path must not tag instants with batching extraMetadata.");
+      assertNull(extra.get("hoodie.clean.batch.totalBatches"),
+          "Legacy path must not tag instants with batching extraMetadata.");
+    }
+  }
+
+  /**
+   * With batch.size configured, one logical clean paginates into multiple
+   * .clean instants. All must record the same targetEarliestCommitToRetain
+   * (the correctness invariant that lets per-partition delete decisions
+   * stay consistent across batches) and cover every batchIndex in
+   * {@code [0, totalBatches)} exactly once.
+   */
+  @Test
+  public void testCleanInBatchesProducesMultipleInstants() throws Exception {
+    int partitionCount = 5;
+    int batchSize = 2;
+    int expectedBatches = (partitionCount + batchSize - 1) / batchSize;
+
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS)
+            .retainFileVersions(1)
+            .withCleanerPlanPartitionsBatchSize(batchSize)
+            .build())
+        .build();
+    seedTwoVersionsPerPartition(config, makePartitions(partitionCount));
+
+    runCleaner(config, 2, true);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    List<HoodieInstant> completed = metaClient.getActiveTimeline().getCleanerTimeline()
+        .filterCompletedInstants().getInstants();
+    assertEquals(expectedBatches, completed.size(),
+        "Batched clean must produce one .clean instant per batch.");
+
+    String sharedTarget = null;
+    Set<String> indicesSeen = new HashSet<>();
+    for (HoodieInstant instant : completed) {
+      Map<String, String> extra = CleanerUtils.getCleanerMetadata(metaClient, instant).getExtraMetadata();
+      assertNotNull(extra, "Batched .clean instant is missing extraMetadata.");
+      assertEquals(String.valueOf(expectedBatches), extra.get("hoodie.clean.batch.totalBatches"),
+          "Every batch must record totalBatches=" + expectedBatches + ".");
+      String target = extra.get("hoodie.clean.batch.targetEarliestCommitToRetain");
+      assertNotNull(target, "Batched .clean instant is missing targetEarliestCommitToRetain.");
+      if (sharedTarget == null) {
+        sharedTarget = target;
+      } else {
+        assertEquals(sharedTarget, target,
+            "All batches in one logical run must share targetEarliestCommitToRetain.");
+      }
+      indicesSeen.add(extra.get("hoodie.clean.batch.batchIndex"));
+    }
+    Set<String> expectedIndices = new HashSet<>();
+    for (int i = 0; i < expectedBatches; i++) {
+      expectedIndices.add(String.valueOf(i));
+    }
+    assertEquals(expectedIndices, indicesSeen,
+        "Every batchIndex in [0, totalBatches) must appear exactly once.");
+  }
+
+  /**
+   * Re-invoking a batched clean when every batch of that logical run has
+   * already completed must be a no-op: the resume-detection scan sees each
+   * batchIndex tagged on the timeline for the same targetEarliestCommit and
+   * skips them. No new .clean instants land. This is the core guarantee
+   * that a crashed-then-resumed run does not reprocess completed batches.
+   */
+  @Test
+  public void testCleanInBatchesResumeSkipsCompletedBatches() throws Exception {
+    int partitionCount = 5;
+    int batchSize = 2;
+    int expectedBatches = (partitionCount + batchSize - 1) / batchSize;
+
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS)
+            .retainFileVersions(1)
+            .withCleanerPlanPartitionsBatchSize(batchSize)
+            .build())
+        .build();
+    seedTwoVersionsPerPartition(config, makePartitions(partitionCount));
+
+    runCleaner(config, 2, true);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    int completedAfterFirstRun = metaClient.getActiveTimeline().getCleanerTimeline()
+        .filterCompletedInstants().getInstants().size();
+    assertEquals(expectedBatches, completedAfterFirstRun,
+        "First batched run must land all batches on the timeline.");
+
+    runCleaner(config, 4, true);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    int completedAfterSecondRun = metaClient.getActiveTimeline().getCleanerTimeline()
+        .filterCompletedInstants().getInstants().size();
+    assertEquals(completedAfterFirstRun, completedAfterSecondRun,
+        "Re-invoking clean when all batches are already complete must not create new .clean instants.");
+  }
+
+  private List<String> makePartitions(int count) {
+    List<String> partitions = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      partitions.add(String.format("2020/01/%02d", i + 1));
+    }
+    return partitions;
+  }
+
+  private void seedTwoVersionsPerPartition(HoodieWriteConfig config, List<String> partitions) throws Exception {
+    try (HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context)) {
+      HoodieTestTable testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
+
+      Map<String, String> fileIdPerPartition = new HashMap<>();
+      Map<String, List<Pair<String, Integer>>> c1 = new HashMap<>();
+      for (String p : partitions) {
+        String fileId = UUID.randomUUID().toString();
+        fileIdPerPartition.put(p, fileId);
+        c1.put(p, Collections.singletonList(Pair.of(fileId, 100)));
+      }
+      testTable.doWriteOperation("00000000000001", WriteOperationType.INSERT, partitions, c1, false, false);
+
+      Map<String, List<Pair<String, Integer>>> c2 = new HashMap<>();
+      for (Map.Entry<String, String> entry : fileIdPerPartition.entrySet()) {
+        c2.put(entry.getKey(), Collections.singletonList(Pair.of(entry.getValue(), 200)));
+      }
+      testTable.doWriteOperation("00000000000003", WriteOperationType.UPSERT, Collections.emptyList(), c2, false, false);
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <spring.shell.version>2.1.1</spring.shell.version>
     <snappy.version>1.1.8.3</snappy.version>
     <heapfork.label>0.15.0-heap-fork</heapfork.label>
-    <heapfork.version>0.2-SNAPSHOT</heapfork.version>
+    <heapfork.version>0.2</heapfork.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <spring.shell.version>2.1.1</spring.shell.version>
     <snappy.version>1.1.8.3</snappy.version>
     <heapfork.label>0.15.0-heap-fork</heapfork.label>
-    <heapfork.version>0.1</heapfork.version>
+    <heapfork.version>0.2-SNAPSHOT</heapfork.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Adds hoodie.clean.plan.partitions.batch.size (default -1, disabled).
When set to a positive value, a single logical clean is paginated into
multiple internally-batched clean instants, each covering at most N
partitions. This avoids serializing one giant HoodieCleanerPlan Avro
array and hitting the JVM Integer.MAX_VALUE byte-array ceiling on
tables with millions of partitions (events-v1: ~6.7M).

Design:

* HoodieCleanConfig: new CLEANER_PLAN_PARTITIONS_BATCH_SIZE property
  and builder method. HoodieWriteConfig: matching getter.
* CleanPlanActionExecutor: added BatchOverride carrying both the
  partition slice AND the pinned earliestInstant.
* BaseHoodieTableServiceClient: at the top of clean(...), when the
  new config is > 0, delegate to a new cleanInBatches() path. 
* HoodieCleaner (utility): no change. The new config key is picked up
  automatically via --hoodie-conf / withProps, and client.clean()
  routes through the modified clean(String, boolean) path.

Non-goals honored: partitionsToClean computation is unchanged, policy
semantics are unchanged, and the incremental-mode/archiver interaction
is untouched. Legacy behavior (batch.size=-1) is preserved.